### PR TITLE
Added support for maintaining the aspect ratio of controls while resizing

### DIFF
--- a/DFGUI/Editor/dfControlInspector.cs
+++ b/DFGUI/Editor/dfControlInspector.cs
@@ -1062,6 +1062,9 @@ public class dfControlInspector : Editor
 					var proportional = EditorGUILayout.Toggle( "Proportional", retVal.IsFlagSet( dfAnchorStyle.Proportional ) );
 					retVal = retVal.SetFlag( dfAnchorStyle.Proportional, proportional );
 
+					var aspect = EditorGUILayout.Toggle( "Maintain Aspect", retVal.IsFlagSet( dfAnchorStyle.MaintainAspect ) );
+					retVal = retVal.SetFlag( dfAnchorStyle.MaintainAspect, aspect );
+
 				}
 				GUILayout.EndVertical();
 

--- a/DFGUI/Scripts/Controls/dfControl.cs
+++ b/DFGUI/Scripts/Controls/dfControl.cs
@@ -5278,6 +5278,12 @@ public abstract class dfControl : MonoBehaviour, IDFControlHost, IComparable<dfC
 				if( anchorStyle.IsFlagSet( dfAnchorStyle.Right ) )
 				{
 					newSize.x = ( margins.right - margins.left ) * parentSize.x;
+
+					if( anchorStyle.IsFlagSet( dfAnchorStyle.MaintainAspect ) )
+					{
+						float aspect = (float)controlSize.y / (float)controlSize.x;
+						newSize.y = newSize.x * aspect;
+					}
 				}
 
 			}
@@ -5295,7 +5301,12 @@ public abstract class dfControl : MonoBehaviour, IDFControlHost, IComparable<dfC
 
 				newPosition.y = top;
 
-				if( anchorStyle.IsFlagSet( dfAnchorStyle.Bottom ) )
+				if( anchorStyle.IsFlagSet( dfAnchorStyle.MaintainAspect ) )
+				{
+					float aspect = (float)controlSize.y / (float)controlSize.x;
+					newSize.y = newSize.x * aspect;
+				}
+				else if( anchorStyle.IsFlagSet( dfAnchorStyle.Bottom ) )
 				{
 					newSize.y = ( margins.bottom - margins.top ) * parentSize.y;
 				}

--- a/DFGUI/Scripts/Internal/dfEnumerations.cs
+++ b/DFGUI/Scripts/Internal/dfEnumerations.cs
@@ -224,6 +224,8 @@ public enum dfAnchorStyle : int
 	CenterVertical = 128,
 	/// <summary>The control layout represents proportional dimensions</summary>
 	Proportional = 256,
+	/// <summary>The control layout represents proportional dimensions</summary>
+	MaintainAspect = 512,
 	/// <summary>The control is not anchored to any edges of its container.</summary>
 	None = 0
 }


### PR DESCRIPTION
Added support for maintaining the aspect ratio of controls while resizing. Allows adapting to multiple screen resolutions (e.g. standard and retina) without distorting when they differ in aspect ratio (e.g. iPhone 4S and iPhone 5).
